### PR TITLE
Add MoreInfo field for debian

### DIFF
--- a/oval/types.go
+++ b/oval/types.go
@@ -36,6 +36,7 @@ type Definition struct {
 	Affecteds   []Affected  `xml:"metadata>affected"`
 	References  []Reference `xml:"metadata>reference"`
 	Description string      `xml:"metadata>description"`
+	MoreInfo    string      `xml:"metadata>debian>moreinfo"` // Debian only
 	Advisory    Advisory    `xml:"metadata>advisory"`
 	Criteria    Criteria    `xml:"criteria"`
 }

--- a/oval/types.go
+++ b/oval/types.go
@@ -36,8 +36,8 @@ type Definition struct {
 	Affecteds   []Affected  `xml:"metadata>affected"`
 	References  []Reference `xml:"metadata>reference"`
 	Description string      `xml:"metadata>description"`
-	MoreInfo    string      `xml:"metadata>debian>moreinfo"` // Debian only
-	Advisory    Advisory    `xml:"metadata>advisory"`
+	Advisory    Advisory    `xml:"metadata>advisory"` // RedHat only
+	Debian      Debian      `xml:"metadata>debian"`   // Debian only
 	Criteria    Criteria    `xml:"criteria"`
 }
 
@@ -101,6 +101,13 @@ type Bugzilla struct {
 	ID      string   `xml:"id,attr"`
 	URL     string   `xml:"href,attr"`
 	Title   string   `xml:",chardata"`
+}
+
+// Debian : >definitions>definition>metadata>debian
+type Debian struct {
+	XMLName  xml.Name `xml:"debian"`
+	MoreInfo string   `xml:"moreinfo"`
+	Date     string   `xml:"date"`
 }
 
 // Tests : >tests


### PR DESCRIPTION
Debian's OVAL has a moreinfo field in metadata.

```
                 <metadata>
                                <title>CVE-2014-0015</title>                                                                                                                                                      <affected family="unix">                                                                                                                                                                  <platform>Debian GNU/Linux 7.0</platform>
                                        <platform>Debian GNU/Linux 8.2</platform>
                                        <platform>Debian GNU/Linux 6.0</platform>
                                        <platform>Debian GNU/Linux 9.0</platform>
                                        <product>curl</product>
                                </affected>
                                <reference ref_id="CVE-2014-0015" ref_url="http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-0015" source="CVE"/>
                                <description>cURL and libcurl 7.10.6 through 7.34.0, when more than one authentication method is enabled, re-uses NTLM connections, which might allow context-dependent attackers to authenticate as other users via a request.</description>
                                <debian>
                                        <date>2014-01-31</date>
                                        <moreinfo>
DSA-2849
Paras Sethia discovered that libcurl, a client-side URL transfer
library, would sometimes mix up multiple HTTP and HTTPS connections
with NTLM authentication to the same server, sending requests for one
user over the connection authenticated as a different user.
</moreinfo>
                                </debian>
                        </metadata>
        
```
