### PR TITLE
Add Advisory-refs field for Ubuntu OVAL

### DIFF
--- a/example.go
+++ b/example.go
@@ -22,6 +22,7 @@ func main() {
 			fmt.Println(err.Error())
 		}
 		pp.Println(oval)
+		pp.Println(oval.Definitions.Definitions[0].Debian)
 	}
 }
 

--- a/oval/types.go
+++ b/oval/types.go
@@ -36,8 +36,8 @@ type Definition struct {
 	Affecteds   []Affected  `xml:"metadata>affected"`
 	References  []Reference `xml:"metadata>reference"`
 	Description string      `xml:"metadata>description"`
-	Advisory    Advisory    `xml:"metadata>advisory"` // RedHat only
-	Debian      Debian      `xml:"metadata>debian"`   // Debian only
+	Advisory    Advisory    `xml:"metadata>advisory"` // RedHat, Oracle, Ubuntu
+	Debian      Debian      `xml:"metadata>debian"`   // Debian
 	Criteria    Criteria    `xml:"criteria"`
 }
 
@@ -73,13 +73,21 @@ type Reference struct {
 }
 
 // Advisory : >definitions>definition>metadata>advisory
-// RedHat OVAL
+// RedHat and Ubuntu OVAL
 type Advisory struct {
 	XMLName         xml.Name   `xml:"advisory"`
 	Severity        string     `xml:"severity"`
 	Cves            []Cve      `xml:"cve"`
 	Bugzillas       []Bugzilla `xml:"bugzilla"`
 	AffectedCPEList []string   `xml:"affected_cpe_list>cpe"`
+	Refs            []Ref      `xml:"ref"` // Ubuntu Only
+}
+
+// Ref : >definitions>definition>metadata>advisory>ref
+// Ubuntu OVAL
+type Ref struct {
+	XMLName xml.Name `xml:"ref"`
+	URL     string   `xml:",chardata"`
 }
 
 // Cve : >definitions>definition>metadata>advisory>cve


### PR DESCRIPTION
There is Advisory>Ref field on Ubuntu OVAL
```
                <advisory>
                    <severity>Medium</severity>
                    <rights>Copyright (C) 2016 Canonical Ltd.</rights>
                    <public_date>2016-05-09</public_date>
                    <ref>http://people.canonical.com/~ubuntu-security/cve/2016/CVE-2016-2442.html</ref>
                    <ref>http://source.android.com/security/bulletin/2016-05-01.html</ref>
                </advisory>
```

Ubuntu OVAL is here 
https://people.canonical.com/~ubuntu-security/oval/