### PR TITLE
feat(redhat): read more RedHat OVAL

### DIFF
--- a/oval/types.go
+++ b/oval/types.go
@@ -77,13 +77,14 @@ type Reference struct {
 // Advisory : >definitions>definition>metadata>advisory
 // RedHat and Ubuntu OVAL
 type Advisory struct {
-	XMLName         xml.Name   `xml:"advisory"`
-	Severity        string     `xml:"severity"`
-	Cves            []Cve      `xml:"cve"`
-	Bugzillas       []Bugzilla `xml:"bugzilla"`
-	AffectedCPEList []string   `xml:"affected_cpe_list>cpe"`
-	Refs            []Ref      `xml:"ref"` // Ubuntu Only
-	Bugs            []Bug      `xml:"bug"` // Ubuntu Only
+	XMLName         xml.Name     `xml:"advisory"`
+	Severity        string       `xml:"severity"`
+	Cves            []Cve        `xml:"cve"`
+	Bugzillas       []Bugzilla   `xml:"bugzilla"`
+	AffectedCPEList []string     `xml:"affected_cpe_list>cpe"`
+	Refs            []Ref        `xml:"ref"` // Ubuntu Only
+	Bugs            []Bug        `xml:"bug"` // Ubuntu Only
+	Affected        AffectedPkgs `xml:"affected"`
 	Issued          struct {
 		Date string `xml:"date,attr"`
 	} `xml:"issued"`
@@ -126,6 +127,15 @@ type Bugzilla struct {
 	ID      string   `xml:"id,attr"`
 	URL     string   `xml:"href,attr"`
 	Title   string   `xml:",chardata"`
+}
+
+// AffectedPkgs : >definitions>definition>metadata>advisory>affected
+// RedHat OVAL
+type AffectedPkgs struct {
+	Resolution struct {
+		State     string   `xml:"state,attr"`
+		Component []string `xml:"component"`
+	} `xml:"resolution"`
 }
 
 // Debian : >definitions>definition>metadata>debian

--- a/oval/types.go
+++ b/oval/types.go
@@ -137,9 +137,13 @@ type Debian struct {
 
 // Tests : >tests
 type Tests struct {
-	XMLName        xml.Name        `xml:"tests"`
-	LineTests      []LineTest      `xml:"line_test"`
-	Version55Tests []Version55Test `xml:"version55_test"`
+	XMLName                xml.Name                `xml:"tests"`
+	LineTests              []LineTest              `xml:"line_test"`
+	Version55Tests         []Version55Test         `xml:"version55_test"`
+	RpminfoTests           []RpminfoTest           `xml:"rpminfo_test"`
+	RpmverifyfileTests     []RpmverifyfileTest     `xml:"rpmverifyfile_test"`
+	Textfilecontent54Tests []Textfilecontent54Test `xml:"textfilecontent54_test"`
+	UnameTests             []UnameTest             `xml:"uname_test"`
 }
 
 // LineTest : >tests>line_test
@@ -162,25 +166,80 @@ type Version55Test struct {
 	Comment       string      `xml:"comment,attr"`
 }
 
+// RpminfoTest : >tests>rpminfo_test
+type RpminfoTest struct {
+	Check          string    `xml:"check,attr"`
+	Comment        string    `xml:"comment,attr"`
+	ID             string    `xml:"id,attr"`
+	Version        string    `xml:"version,attr"`
+	CheckExistence string    `xml:"check_existence,attr"`
+	Object         ObjectRef `xml:"object"`
+	State          StateRef  `xml:"state"`
+}
+
+// RpmverifyfileTest : tests>rpmverifyfile_test
+type RpmverifyfileTest struct {
+	Check   string    `xml:"check,attr"`
+	Comment string    `xml:"comment,attr"`
+	ID      string    `xml:"id,attr"`
+	Version string    `xml:"version,attr"`
+	Object  ObjectRef `xml:"object"`
+	State   StateRef  `xml:"state"`
+}
+
+// Textfilecontent54Test : tests>textfilecontent54_test
+type Textfilecontent54Test struct {
+	Check   string    `xml:"check,attr"`
+	Comment string    `xml:"comment,attr"`
+	ID      string    `xml:"id,attr"`
+	Version string    `xml:"version,attr"`
+	Object  ObjectRef `xml:"object"`
+	State   StateRef  `xml:"state"`
+}
+
+// UnameTest : tests>uname_test
+type UnameTest struct {
+	Check   string    `xml:"check,attr"`
+	Comment string    `xml:"comment,attr"`
+	ID      string    `xml:"id,attr"`
+	Version string    `xml:"version,attr"`
+	Object  ObjectRef `xml:"object"`
+	State   StateRef  `xml:"state"`
+}
+
 // ObjectRef : >tests>line_test>object-object_ref
 //           : >tests>version55_test>object-object_ref
+//           : >tests>rpminfo_test>object-object_ref
+//           : >tests>rpmverifyfile_test>object-object_ref
+//           : >tests>textfilecontent54_test>object-object_ref
+//           : >tests>uname_test>object-object_ref
 type ObjectRef struct {
 	XMLName   xml.Name `xml:"object"`
+	Text      string   `xml:",chardata"`
 	ObjectRef string   `xml:"object_ref,attr"`
 }
 
 // StateRef : >tests>line_test>state-state_ref
 //          : >tests>version55_test>state-state_ref
+//           : >tests>rpminfo_test>state-state_ref
+//           : >tests>rpmverifyfile_test>state-state_ref
+//           : >tests>textfilecontent54_test>state-state_ref
+//           : >tests>uname_test>state-state_ref
 type StateRef struct {
 	XMLName  xml.Name `xml:"state"`
+	Text     string   `xml:",chardata"`
 	StateRef string   `xml:"state_ref,attr"`
 }
 
 // Objects : >objects
 type Objects struct {
-	XMLName          xml.Name          `xml:"objects"`
-	LineObjects      []LineObject      `xml:"line_object"`
-	Version55Objects []Version55Object `xml:"version55_object"`
+	XMLName                  xml.Name                  `xml:"objects"`
+	LineObjects              []LineObject              `xml:"line_object"`
+	Version55Objects         []Version55Object         `xml:"version55_object"`
+	RpminfoObjects           []RpminfoObject           `xml:"rpminfo_object"`
+	RpmverifyfileObjects     []RpmverifyfileObject     `xml:"rpmverifyfile_object"`
+	Textfilecontent54Objects []Textfilecontent54Object `xml:"textfilecontent54_object"`
+	UnameObjects             []UnameObject             `xml:"uname_object"`
 }
 
 // LineObject : >objects>line_object
@@ -196,11 +255,87 @@ type Version55Object struct {
 	ID      string   `xml:"id,attr"`
 }
 
+// RpminfoObject : >objects>rpminfo_object
+type RpminfoObject struct {
+	ID      string `xml:"id,attr"`
+	Version string `xml:"version,attr"`
+	Name    string `xml:"name"`
+}
+
+// RpmverifyfileObject : >objects>rpmverifyfile_object
+type RpmverifyfileObject struct {
+	ID          string `xml:"id,attr"`
+	AttrVersion string `xml:"version,attr"`
+	Behaviors   struct {
+		Text          string `xml:",chardata"`
+		Noconfigfiles string `xml:"noconfigfiles,attr"`
+		Noghostfiles  string `xml:"noghostfiles,attr"`
+		Nogroup       string `xml:"nogroup,attr"`
+		Nolinkto      string `xml:"nolinkto,attr"`
+		Nomd5         string `xml:"nomd5,attr"`
+		Nomode        string `xml:"nomode,attr"`
+		Nomtime       string `xml:"nomtime,attr"`
+		Nordev        string `xml:"nordev,attr"`
+		Nosize        string `xml:"nosize,attr"`
+		Nouser        string `xml:"nouser,attr"`
+	} `xml:"behaviors"`
+	Name struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"name"`
+	Epoch struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"epoch"`
+	Version struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"version"`
+	Release struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"release"`
+	Arch struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"arch"`
+	Filepath string `xml:"filepath"`
+}
+
+// Textfilecontent54Object : >objects>textfilecontent54_object
+type Textfilecontent54Object struct {
+	ID       string `xml:"id,attr"`
+	Version  string `xml:"version,attr"`
+	Filepath struct {
+		Text     string `xml:",chardata"`
+		Datatype string `xml:"datatype,attr"`
+	} `xml:"filepath"`
+	Pattern struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"pattern"`
+	Instance struct {
+		Text     string `xml:",chardata"`
+		Datatype string `xml:"datatype,attr"`
+		VarRef   string `xml:"var_ref,attr"`
+	} `xml:"instance"`
+}
+
+// UnameObject : >objects>uname_object
+type UnameObject struct {
+	ID      string `xml:"id,attr"`
+	Version string `xml:"version,attr"`
+}
+
 // States : >states
 type States struct {
-	XMLName         xml.Name         `xml:"states"`
-	LineStates      []LineState      `xml:"line_state"`
-	Version55States []Version55State `xml:"version55_state"`
+	XMLName                 xml.Name                 `xml:"states"`
+	LineStates              []LineState              `xml:"line_state"`
+	Version55States         []Version55State         `xml:"version55_state"`
+	RpminfoStates           []RpminfoState           `xml:"rpminfo_state"`
+	RpmverifyfileStates     []RpmverifyfileState     `xml:"rpmverifyfile_state"`
+	Textfilecontent54States []Textfilecontent54State `xml:"textfilecontent54_state"`
+	UnameStates             []UnameState             `xml:"uname_state"`
 }
 
 // LineState : >states>line_state
@@ -223,4 +358,58 @@ type Version55State struct {
 	XMLName       xml.Name `xml:"version55_state"`
 	ID            string   `xml:"id,attr"`
 	VersionString string   `xml:"version_string"`
+}
+
+// RpminfoState : >states>rpminfo_state
+type RpminfoState struct {
+	ID      string `xml:"id,attr"`
+	Version string `xml:"version,attr"`
+	Evr     struct {
+		Text      string `xml:",chardata"`
+		Datatype  string `xml:"datatype,attr"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"evr"`
+	SignatureKeyid struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"signature_keyid"`
+	Arch struct {
+		Text      string `xml:",chardata"`
+		Datatype  string `xml:"datatype,attr"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"arch"`
+}
+
+// RpmverifyfileState : >states>rpmverifyfile_state
+type RpmverifyfileState struct {
+	ID          string `xml:"id,attr"`
+	AttrVersion string `xml:"version,attr"`
+	Name        struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"name"`
+	Version struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"version"`
+}
+
+// Textfilecontent54State : >states>textfilecontent54_state
+type Textfilecontent54State struct {
+	ID      string `xml:"id,attr"`
+	Version string `xml:"version,attr"`
+	Text    struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"text"`
+}
+
+// UnameState : >states>uname_state
+type UnameState struct {
+	ID        string `xml:"id,attr"`
+	Version   string `xml:"version,attr"`
+	OsRelease struct {
+		Text      string `xml:",chardata"`
+		Operation string `xml:"operation,attr"`
+	} `xml:"os_release"`
 }

--- a/oval/types.go
+++ b/oval/types.go
@@ -369,15 +369,18 @@ type RpminfoState struct {
 		Datatype  string `xml:"datatype,attr"`
 		Operation string `xml:"operation,attr"`
 	} `xml:"evr"`
-	SignatureKeyid struct {
-		Text      string `xml:",chardata"`
-		Operation string `xml:"operation,attr"`
-	} `xml:"signature_keyid"`
-	Arch struct {
+	SignatureKeyid SignatureKeyid `xml:"signature_keyid"`
+	Arch           struct {
 		Text      string `xml:",chardata"`
 		Datatype  string `xml:"datatype,attr"`
 		Operation string `xml:"operation,attr"`
 	} `xml:"arch"`
+}
+
+// SignatureKeyid : >states>rpminfo_state>signature_keyid
+type SignatureKeyid struct {
+	Text      string `xml:",chardata"`
+	Operation string `xml:"operation,attr"`
 }
 
 // RpmverifyfileState : >states>rpmverifyfile_state


### PR DESCRIPTION
It allows to read something like the following.
```xml
<definitions>
    <definition>
        <advisory>
            <affected>
                <resolution state="Will not fix">
                    <component>libxslt</component>
                    <component>libxslt-debugsource</component>
                    <component>libxslt-devel</component>
                </resolution>
            </affected>
        </advisory>
    </definition>
</definitions>
<tests>
    <red-def:rpminfo_test check="at least one" comment="kernel version equals 0:4.18.0-193.el8" id="oval:com.redhat.rhsa:tst:20202125001" version="637">
        <red-def:object object_ref="oval:com.redhat.rhsa:obj:20191167002"/>
        <red-def:state state_ref="oval:com.redhat.rhsa:ste:20202125002"/>
    </red-def:rpminfo_test>
</tests>
<objects>
    <red-def:rpminfo_object id="oval:com.redhat.rhsa:obj:20191167002" version="643">
        <red-def:name>kernel</red-def:name>
    </red-def:rpminfo_object>
</objects>
<states>
    <red-def:rpminfo_state id="oval:com.redhat.rhsa:ste:20202125002" version="637">
        <red-def:arch datatype="string" operation="pattern match">ppc64le|x86_64</red-def:arch>
        <red-def:evr datatype="evr_string" operation="equals">0:4.18.0-193.el8</red-def:evr>
    </red-def:rpminfo_state>
</states>

```